### PR TITLE
Stop automerging minor bumps of @blalena/open-balena-api

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -116,6 +116,11 @@
         "patch",
         "digest"
       ]
+    },
+    {
+      "automerge": false,
+      "matchPackageNames": ["@balena/open-balena-api"],
+      "matchUpdateTypes": ["minor"]
     }
   ]
 }


### PR DESCRIPTION
This is in an effort to avoid merging a PR that
adds a new field for which we need to write a
migration in the balena-api.

Change-type: patch
See: https://jel.ly.fish/thread-3605662d-f0c4-4669-bd42-2187a9b919aa
See: https://docs.renovatebot.com/configuration-options/#packagerules