### PR TITLE
Replace repo.yml as VB throws up without it

### DIFF
--- a/repo.yml
+++ b/repo.yml
@@ -1,0 +1,2 @@
+---
+type: generic


### PR DESCRIPTION
* we should change VB's assumption about missing repo.yml == Node project which I don't believe is a safe assumption to make (e.g. this repo doesn't have package.json and doesn't need it)

Change-type: patch