### PR TITLE
Update name of etcherPro-fleet-sw repo

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -37,7 +37,7 @@
   ],
   "repositories": [
 
-    "balena-io-hardware/etcherpro-fleet",
+    "balena-io-hardware/etcherPro-fleet-sw",
 
 
     "balena-io-modules/abstract-sql-compiler",


### PR DESCRIPTION
Repo names need to be manually updated until [this](https://github.com/renovatebot/renovate/discussions/19159) is resolved.

Do not merge until the role of the `balena-io-hardware` copy is [resolved](https://balena.zulipchat.com/#narrow/stream/345891-loop.2Fbalena-io-hardware/topic/Updating.20*all*.20hw.20repos.20to.20naming.20convention/near/312760169).