### PR TITLE
Remove balena-io-hardware repo

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -37,9 +37,6 @@
   ],
   "repositories": [
 
-    "balena-io-hardware/etcherpro-fleet",
-
-
     "balena-io-modules/abstract-sql-compiler",
     "balena-io-modules/abstract-sql-to-typescript",
     "balena-io-modules/odata-to-abstract-sql",


### PR DESCRIPTION
Moved to [balena-io-hardware/meta-renovateConfig-sw](https://github.com/balena-io-hardware/meta-renovateConfig-sw) instead.