### PR TITLE
Fix extractVersion, add tests

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -143,7 +143,7 @@
       ],
       "depNameTemplate": "prometheus/prometheus",
       "datasourceTemplate": "github-releases",
-      "extractVersion": "^v(?<version>.*)$"
+      "extractVersionTemplate": "^v(?<version>.*)$"
     },
     {
       "fileMatch": [
@@ -155,7 +155,7 @@
       ],
       "depNameTemplate": "grafana/grafana",
       "datasourceTemplate": "github-releases",
-      "extractVersion": "^v(?<version>.*)$"
+      "extractVersionTemplate": "^v(?<version>.*)$"
     },
     {
       "fileMatch": [

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@balena/balena-io-renovate-config",
+  "version": "0.124.1",
+  "private": true,
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/balena-io/renovate-config.git"
+  },
+  "description": "Shared renovate configuration and GitHub Action",
+  "scripts": {
+    "test": "renovate-config-validator ./.github/renovate.json"
+  },
+  "author": "Balena.io. <hello@balena.io>",
+  "license": "Apache-2.0",
+  "devDependencies": {
+    "renovate": "^34.55.0"
+  }
+}

--- a/repo.yml
+++ b/repo.yml
@@ -1,2 +1,1 @@
----
-type: generic
+type: node


### PR DESCRIPTION
Change-type: patch

***

- Replace `extractVersion` with `extractVersionTemplate`, as `extractVersion` is invalid:
```
ERROR: ./.github/renovate.json contains errors
       "errors": [
         {
           "topic": "Configuration Error",
           "message": "Regex Manager contains disallowed fields: extractVersion"
         }
       ]
```
- Add tests to catch invalid renovate configs