### PR TITLE
Enable pre-commit

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,5 +1,6 @@
 {
   "extends": [
+    ":enablePreCommit",
     ":preserveSemverRanges",
     "config:base",
     "docker:enableMajor",
@@ -18,6 +19,7 @@
     "renovate",
     "dependencies"
   ],
+  "platformAutomerge": true,
   "automergeComment": "@balena-ci I self-certify!",
   "automergeType": "pr-comment",
   "commitMessageExtra": "to {{{replace 'v' '' newVersion}}}",


### PR DESCRIPTION
https://pre-commit.com/, but [caveat](https://github.com/renovatebot/renovate/blob/main/lib/modules/manager/pre-commit/readme.md)

(e.g. https://github.com/renovatebot/pre-commit-hooks)

