### PR TITLE
Revert  automergeType

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -9,8 +9,6 @@
   "prHourlyLimit": 0,
   "onboarding": false,
   "requireConfig": "optional",
-  "automergeType": "pr-comment",
-  "automergeComment": "LGTM",
   "cloneSubmodules": true,
   "rebaseWhen": "behind-base-branch",
   "git-submodules": {


### PR DESCRIPTION
I am reverting:

```
  "automergeType": "pr-comment",
  "automergeComment": "LGTM",
```

policy-bot never fires the pr-comment, since the *required* check "policy-bot" is never satisfied. So - a circular dependency pattern.