### PR TITLE
renovate balena-io-library/base-images

### DIFF
--- a/default.json
+++ b/default.json
@@ -8,6 +8,9 @@
   "onboarding": false,
   "requireConfig": "optional",
   "repositories": [
+    "balena-io-library/base-images",
+
+
     "balena-io-modules/abstract-sql-compiler",
     "balena-io-modules/abstract-sql-to-typescript",
     "balena-io-modules/balena-deploy-request",


### PR DESCRIPTION
Suspect renovate will struggle to complete with this repo: https://github.com/balena-io/renovate-config/actions/runs/4536510356

We are probably better off isolating this repo to its own renovate-config (balena-io-library/renovate-config), but even then the renovate (dry-run) fails to complete in 3hrs.