### PR TITLE
Remove custom versioning for self-hosted runners

### DIFF
--- a/default.json
+++ b/default.json
@@ -121,11 +121,6 @@
       "automerge": true
     },
     {
-      "matchPackagePatterns": [".*product-os/self-hosted-runners$"],
-      "matchDatasources": ["docker"],
-      "versioning": "regex:^((?<compatibility>.*)-)?v?(?<major>\\d+)(\\.(?<minor>\\d+))?(\\.(?<patch>\\d+))?$"
-    },
-    {
       "automerge": false,
       "matchPackageNames": ["@balena/open-balena-api"],
       "matchUpdateTypes": ["minor"]


### PR DESCRIPTION
As of v1.2.8 the self-hosted runner docker tags are following the expected semver-compatibility syntax.

Change-type: patch