### PR TITLE
Disable automerge for all update types

### DIFF
--- a/default.json
+++ b/default.json
@@ -85,23 +85,21 @@
   "labels": ["renovate", "dependencies", "{{depType}}", "{{updateType}}"],
   "prConcurrentLimit": 1,
   "branchConcurrentLimit": 1,
+  "automerge": false,
   "packageRules": [
     {
       "matchUpdateTypes": ["major", "minor", "patch"],
       "commitBody": "Update {{depName}} from {{{replace 'v' '' currentVersion}}} to {{{replace 'v' '' newVersion}}}\n\nChange-type: {{updateType}}",
-      "labels": ["renovate", "dependencies", "{{depType}}", "{{updateType}}"],
-      "automerge": true
+      "labels": ["renovate", "dependencies", "{{depType}}", "{{updateType}}"]
     },
     {
-      "matchUpdateTypes": ["major"],
-      "automerge": false
+      "matchUpdateTypes": ["major"]
     },
     {
       "matchUpdateTypes": ["minor"],
       "matchCurrentVersion": "<1.0.0",
       "commitBody": "Update {{depName}} from {{{replace 'v' '' currentVersion}}} to {{{replace 'v' '' newVersion}}}\n\nChange-type: major",
-      "labels": ["renovate", "dependencies", "{{depType}}", "major"],
-      "automerge": false
+      "labels": ["renovate", "dependencies", "{{depType}}", "major"]
     },
     {
       "matchUpdateTypes": ["patch"],
@@ -111,16 +109,13 @@
     },
     {
       "matchUpdateTypes": ["digest"],
-      "commitBody": "Update {{depName}}\n\nChange-type: patch",
-      "automerge": true
+      "commitBody": "Update {{depName}}\n\nChange-type: patch"
     },
     {
       "matchUpdateTypes": ["pin", "pinDigest"],
-      "commitBody": "Pin {{depName}}\n\nChange-type: patch",
-      "automerge": true
+      "commitBody": "Pin {{depName}}\n\nChange-type: patch"
     },
     {
-      "automerge": false,
       "matchPackageNames": ["@balena/open-balena-api"],
       "matchUpdateTypes": ["minor"]
     }


### PR DESCRIPTION
We now use policy-bot and labels to determine if a PR can be merged, and auto-merge is enabled automatically by Flowzone.

Having an external service with Administrator access perform merging can result in PRs merging without all required checks.

Change-type: minor