### PR TITLE
Add some convenience regexmanager presets

### DIFF
--- a/default.json
+++ b/default.json
@@ -4,7 +4,10 @@
     ":preserveSemverRanges",
     "config:base",
     "docker:enableMajor",
-    "helpers:pinGitHubActionDigests"
+    "helpers:pinGitHubActionDigests",
+    "regexManagers:dockerfileVersions",
+    "regexManagers:githubActionsVersions",
+    "regexManagers:tfvarsVersions"
   ],
   "username": "balena-renovate[bot]",
   "gitAuthor": "Self-hosted Renovate Bot <133977723+balena-renovate[bot]@users.noreply.github.com>",


### PR DESCRIPTION
See https://docs.renovatebot.com/presets-regexManagers/

Using these regex managers, we can bump ENV and ARG in Dockerfiles and GitHub Actions and Terraform with annotations.

e.g.

```Dockerfile
# renovate: datasource=github-releases depName=werf/kubedog
ARG KUBEDOG_VERSION=v0.5.1
```