### PR TITLE
Set the commitBody in the digest package rules

### DIFF
--- a/default.json
+++ b/default.json
@@ -72,6 +72,11 @@
   "prConcurrentLimit": 2,
   "automerge": false,
   "pinDigest": {
+    "commitBody": "Update {{depName}}\n\nChange-type: patch",
+    "automerge": true
+  },
+  "digest": {
+    "commitBody": "Update {{depName}}\n\nChange-type: patch",
     "automerge": true
   },
   "packageRules": [


### PR DESCRIPTION
This allows repos in balena-os to extend balena-io/renovate-config and override the commit message for digests.

Change-type: patch