### PR TITLE
Automerge stable minor for versions without range support

### DIFF
--- a/default.json
+++ b/default.json
@@ -93,6 +93,11 @@
       "groupName": "ssh2: @types grouping with sibling package(s)",
       "matchPackagePatterns": ["^(@types/)?ssh2$"],
       "separateMajorMinor": false
+    },
+    {
+      "matchUpdateTypes": ["minor", "patch"],
+      "matchCurrentVersion": "!/^v?0/",
+      "automerge": true
     }
   ]
 }


### PR DESCRIPTION
In addition to the :automergeStableNonMajor preset, we want to automerge stable minor releases even when the versioning scheme does not support ranges in the format >= 1.0.0.

Specifically, the regex versioning used for open-balena-base does not support version ranges, so instead we need to evaluate as a string.

Change-type: patch