### PR TITLE
Increase concurrent PR limit from 2 to 3

### DIFF
--- a/default.json
+++ b/default.json
@@ -69,7 +69,7 @@
   },
   "labels": ["renovate"],
   "commitBody": "Update {{depName}}\n\nChange-type: patch",
-  "prConcurrentLimit": 2,
+  "prConcurrentLimit": 3,
   "automerge": false,
   "automergeStrategy": "merge-commit",
   "pinDigest": {


### PR DESCRIPTION
This will slightly reduce the number of PRs being rate-limited without any notification beyond the dependency dashboard.

Change-type: patch