### PR TITLE
Enable lock file maintenance

### DIFF
--- a/default.json
+++ b/default.json
@@ -81,6 +81,7 @@
     "commitBody": "Update {{depName}}\n\nChange-type: patch",
     "automerge": true
   },
+  "lockFileMaintenance": { "enabled": true },
   "packageRules": [
     {
       "matchDatasources": ["docker"],


### PR DESCRIPTION
See: https://docs.renovatebot.com/configuration-options/#lockfilemaintenance
Change-type: patch

Here are the default settings from the [docs](https://docs.renovatebot.com/configuration-options/#lockfilemaintenance)...
```json
{
  "enabled": false,
  "recreateWhen": "always",
  "rebaseStalePrs": true,
  "branchTopic": "lock-file-maintenance",
  "commitMessageAction": "Lock file maintenance",
  "commitMessageTopic": null,
  "commitMessageExtra": null,
  "schedule": ["before 4am on monday"],
  "groupName": null,
  "prBodyDefinitions": {"Change": "All locks refreshed"}
}
```