### PR TITLE
correct allowedPostUpgradeCommands trust

### DIFF
--- a/default.json
+++ b/default.json
@@ -23,7 +23,8 @@
   ],
   "onboarding": false,
   "allowPostUpgradeCommandTemplating": true,
-  "allowedPostUpgradeCommands": ["^npm", "^cd"],
+  "allowedPostUpgradeCommands": ["^npm\\s+", "^cd\\s+", "^pushd\\s+"],
+  "trustLevel": "high",
   "requireConfig": "optional",
   "repositories": [
     "balena-io/analytics-backend",


### PR DESCRIPTION
### [allowedPostUpgradeCommands](https://github.com/daekene/renovate/blob/master/docs/usage/self-hosted-configuration.md#allowedpostupgradecommands )

> A list of regular expressions that determine which commands in postUpgradeTasks are allowed to be executed. If this list is empty then no tasks will be executed. Also you need to have "trustLevel": "high", otherwise these tasks will be ignored.

.. according to the docs, these wouldn't have been working because `trustLevel": "high"` wasn't set.