### PR TITLE
Disable automerge of major npm types

### DIFF
--- a/default.json
+++ b/default.json
@@ -11,7 +11,6 @@
     ":automergeStableNonMajor",
     ":automergePatch",
     ":automergeDigest",
-    ":automergeTypes",
     "npm:unpublishSafe",
     ":semanticCommitsDisabled"
   ],


### PR DESCRIPTION
Change-type: patch
See: https://docs.renovatebot.com/presets-default/#automergetypes
See: https://balena.zulipchat.com/#narrow/stream/345752-balena-io.2Finternal-tooling/topic/Renovate.20major.20change-types