### PR TITLE
Remove "with types" from npm package group name

### DIFF
--- a/default.json
+++ b/default.json
@@ -101,13 +101,13 @@
       "commitBody": "Update {{depName}} from {{{replace 'v' '' currentVersion}}} to {{{replace 'v' '' newVersion}}}\n\nChange-type: patch"
     },
     {
-      "groupName": "{{{replace '^@types/' '' depName}}} with types",
+      "groupName": "{{{replace '^@types/' '' depName}}}",
       "matchPackagePrefixes": ["@types/"],
       "matchDepTypes": ["dependencies", "devDependencies"],
       "matchDatasources": ["npm"]
     },
     {
-      "groupName": "{{depName}} with types",
+      "groupName": "{{depName}}",
       "excludePackagePrefixes": ["@types/"],
       "matchDepTypes": ["dependencies", "devDependencies"],
       "matchDatasources": ["npm"]


### PR DESCRIPTION
In many cases @types are not available at the same as the package so the PR name and branch is misleading.

Just remove the "with types" from the name but
keep the grouping (@types/depName joins depName).

Change-type: minor