### PR TITLE
Remove no-systemd-v from open-balena-base updates commit body

### DIFF
--- a/default.json
+++ b/default.json
@@ -101,6 +101,12 @@
       "commitBody": "Update {{depName}} from {{{replace 'v' '' currentVersion}}} to {{{replace 'v' '' newVersion}}}\n\nChange-type: patch"
     },
     {
+      "matchPackagePatterns": ["^balena/open-balena-base$"],
+      "matchUpdateTypes": ["major", "minor", "patch"],
+      "matchCurrentValue": "/^no-systemd-v/",
+      "commitBody": "Update {{depName}} from {{{replace 'no-systemd-v' '' currentVersion}}} to {{{replace 'no-systemd-v' '' newVersion}}}\n\nChange-type: patch"
+    },
+    {
       "groupName": "{{{replace '^@types/' '' depName}}}",
       "matchPackagePrefixes": ["@types/"],
       "matchDepTypes": ["dependencies", "devDependencies"],


### PR DESCRIPTION
Renovate expects the "compatibility" field to be a suffix of the semver, not a prefix, so we need workarounds like this to handle the commit body message.

Change-type: patch