### PR TITLE
Patch prepare script on husky major updates

### DIFF
--- a/default.json
+++ b/default.json
@@ -132,9 +132,11 @@
       "matchUpdateTypes": ["major"],
       "postUpgradeTasks": {
         "commands": [
-          "jq '.scripts.prepare |= if . == \"node -e \\\"try { require(\\'husky\\').install() } catch (e) {if (e.code !== \\'MODULE_NOT_FOUND\\') throw e}\\\"\" then \"node -e \\\"try { (await import(\\'husky\\')).default() } catch (e) { if (e.code !== \\'ERR_MODULE_NOT_FOUND\\') throw e }\\\" --input-type module\" else . end' package.json > package.json.tmp && mv package.json.tmp package.json"
+          "jq '.scripts.prepare |= if . == \"node -e \\\"try { require(\\'husky\\').install() } catch (e) {if (e.code !== \\'MODULE_NOT_FOUND\\') throw e}\\\"\" then \"node -e \\\"try { (await import(\\'husky\\')).default() } catch (e) { if (e.code !== \\'ERR_MODULE_NOT_FOUND\\') throw e }\\\" --input-type module\" else . end' package.json > package.json.tmp && mv package.json.tmp package.json",
+          "sed '/#!/d' -i .husky/pre-commit",
+          "sed '/husky.sh/d' -i .husky/pre-commit"
         ],
-        "fileFilters": ["package.json"]
+        "fileFilters": ["package.json", ".husky/pre-commit"]
       }
     }
   ]

--- a/default.json
+++ b/default.json
@@ -22,7 +22,7 @@
   ],
   "onboarding": false,
   "allowPostUpgradeCommandTemplating": true,
-  "allowedPostUpgradeCommands": ["^npm", "^cd", "^sed"],
+  "allowedPostUpgradeCommands": ["^npm", "^cd", "^sed", "^jq"],
   "requireConfig": "optional",
   "repositories": [
     "balena-io/analytics-backend",
@@ -126,6 +126,16 @@
     {
       "matchRepositories": ["balena-io/balena-ui"],
       "commitBody": "Update {{depName}}\n\nChangelog-entry: Update {{depName}}\nChange-type: patch"
+    },
+    {
+      "matchPackagePatterns": ["^husky$"],
+      "matchUpdateTypes": ["major"],
+      "postUpgradeTasks": {
+        "commands": [
+          "jq '.scripts.prepare |= if . == \"node -e \\\"try { require(\\'husky\\').install() } catch (e) {if (e.code !== \\'MODULE_NOT_FOUND\\') throw e}\\\"\" then \"node -e \\\"try { (await import(\\'husky\\')).default() } catch (e) { if (e.code !== \\'ERR_MODULE_NOT_FOUND\\') throw e }\\\" --input-type module\" else . end' package.json > package.json.tmp && mv package.json.tmp package.json"
+        ],
+        "fileFilters": ["package.json"]
+      }
     }
   ]
 }


### PR DESCRIPTION
See: https://github.com/typicode/husky/releases/tag/v9.0.1
Change-type: patch

Matches `prepare` script
```json
"node -e \"try { require('husky').install() } catch (e) {if (e.code !== 'MODULE_NOT_FOUND') throw e}\""
```
and replaces it with
```json
"node -e \"try { (await import('husky')).default() } catch (e) { if (e.code !== 'ERR_MODULE_NOT_FOUND') throw e }\" --input-type module"
```
on `major` updates to the `husky` package

also removes these lines from `.husky/pre-commit`
```shell
#!/usr/bin/env sh
. "$(dirname -- "$0")/_/husky.sh"
```

... and fortunately for us, major updates are configured to not automerge so we will catch any errors in this process