### PR TITLE
Fix husky postUpgradeTasks to use base64-encoded script

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+# shellcheck disable=SC2148
+node updatePackageRules.js
+npm run lint:fix
+git add default.json

--- a/commands/husky-v9-patch.js
+++ b/commands/husky-v9-patch.js
@@ -1,0 +1,26 @@
+const fs = require("fs");
+
+// Update package.json
+const packageJsonPath = "package.json";
+const data = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
+data.scripts.prepare =
+  data.scripts.prepare ===
+  "node -e \"try { require('husky').install() } catch (e) {if (e.code !== 'MODULE_NOT_FOUND') throw e}\""
+    ? "node -e \"try { (await import('husky')).default() } catch (e) { if (e.code !== 'ERR_MODULE_NOT_FOUND') throw e }\" --input-type module"
+    : data.scripts.prepare;
+fs.writeFileSync(packageJsonPath, JSON.stringify(data, null, 2));
+
+// Update .husky/pre-commit
+const preCommitPath = ".husky/pre-commit";
+if (fs.existsSync(preCommitPath)) {
+  let content = fs.readFileSync(preCommitPath, "utf8");
+  const linesToRemove = [
+    "#!/usr/bin/env sh",
+    '. "$(dirname -- "$0")/_/husky.sh"',
+  ];
+  content = content
+    .split("\n")
+    .filter((line) => !linesToRemove.includes(line))
+    .join("\n");
+  fs.writeFileSync(preCommitPath, content);
+}

--- a/default.json
+++ b/default.json
@@ -22,7 +22,7 @@
   ],
   "onboarding": false,
   "allowPostUpgradeCommandTemplating": true,
-  "allowedPostUpgradeCommands": ["^npm", "^cd", "^sed", "^jq"],
+  "allowedPostUpgradeCommands": ["^npm", "^cd", "^sed", "^node"],
   "requireConfig": "optional",
   "repositories": [
     "balena-io/analytics-backend",
@@ -132,9 +132,7 @@
       "matchUpdateTypes": ["major"],
       "postUpgradeTasks": {
         "commands": [
-          "jq '.scripts.prepare |= if . == \"node -e \\\"try { require(\\'husky\\').install() } catch (e) {if (e.code !== \\'MODULE_NOT_FOUND\\') throw e}\\\"\" then \"node -e \\\"try { (await import(\\'husky\\')).default() } catch (e) { if (e.code !== \\'ERR_MODULE_NOT_FOUND\\') throw e }\\\" --input-type module\" else . end' package.json > package.json.tmp && mv package.json.tmp package.json",
-          "sed '/#!/d' -i .husky/pre-commit",
-          "sed '/husky.sh/d' -i .husky/pre-commit"
+          "node -e \"eval(Buffer.from('Y29uc3QgZnMgPSByZXF1aXJlKCJmcyIpOwoKLy8gVXBkYXRlIHBhY2thZ2UuanNvbgpjb25zdCBwYWNrYWdlSnNvblBhdGggPSAicGFja2FnZS5qc29uIjsKY29uc3QgZGF0YSA9IEpTT04ucGFyc2UoZnMucmVhZEZpbGVTeW5jKHBhY2thZ2VKc29uUGF0aCwgInV0ZjgiKSk7CmRhdGEuc2NyaXB0cy5wcmVwYXJlID0KICBkYXRhLnNjcmlwdHMucHJlcGFyZSA9PT0KICAibm9kZSAtZSBcInRyeSB7IHJlcXVpcmUoJ2h1c2t5JykuaW5zdGFsbCgpIH0gY2F0Y2ggKGUpIHtpZiAoZS5jb2RlICE9PSAnTU9EVUxFX05PVF9GT1VORCcpIHRocm93IGV9XCIiCiAgICA/ICJub2RlIC1lIFwidHJ5IHsgKGF3YWl0IGltcG9ydCgnaHVza3knKSkuZGVmYXVsdCgpIH0gY2F0Y2ggKGUpIHsgaWYgKGUuY29kZSAhPT0gJ0VSUl9NT0RVTEVfTk9UX0ZPVU5EJykgdGhyb3cgZSB9XCIgLS1pbnB1dC10eXBlIG1vZHVsZSIKICAgIDogZGF0YS5zY3JpcHRzLnByZXBhcmU7CmZzLndyaXRlRmlsZVN5bmMocGFja2FnZUpzb25QYXRoLCBKU09OLnN0cmluZ2lmeShkYXRhLCBudWxsLCAyKSk7CgovLyBVcGRhdGUgLmh1c2t5L3ByZS1jb21taXQKY29uc3QgcHJlQ29tbWl0UGF0aCA9ICIuaHVza3kvcHJlLWNvbW1pdCI7CmlmIChmcy5leGlzdHNTeW5jKHByZUNvbW1pdFBhdGgpKSB7CiAgbGV0IGNvbnRlbnQgPSBmcy5yZWFkRmlsZVN5bmMocHJlQ29tbWl0UGF0aCwgInV0ZjgiKTsKICBjb25zdCBsaW5lc1RvUmVtb3ZlID0gWwogICAgIiMhL3Vzci9iaW4vZW52IHNoIiwKICAgICcuICIkKGRpcm5hbWUgLS0gIiQwIikvXy9odXNreS5zaCInLAogIF07CiAgY29udGVudCA9IGNvbnRlbnQKICAgIC5zcGxpdCgiXG4iKQogICAgLmZpbHRlcigobGluZSkgPT4gIWxpbmVzVG9SZW1vdmUuaW5jbHVkZXMobGluZSkpCiAgICAuam9pbigiXG4iKTsKICBmcy53cml0ZUZpbGVTeW5jKHByZUNvbW1pdFBhdGgsIGNvbnRlbnQpOwp9Cg==', 'base64').toString('utf-8'))\""
         ],
         "fileFilters": ["package.json", ".husky/pre-commit"]
       }

--- a/package.json
+++ b/package.json
@@ -8,11 +8,15 @@
   },
   "description": "Shared renovate configuration and GitHub Action",
   "scripts": {
-    "test": "renovate-config-validator default.json"
+    "test": "renovate-config-validator default.json",
+    "lint:fix": "prettier --write default.json",
+    "prepare": "node -e \"try { (await import('husky')).default() } catch (e) { if (e.code !== 'ERR_MODULE_NOT_FOUND') throw e }\" --input-type module"
   },
   "author": "Balena.io. <hello@balena.io>",
   "license": "Apache-2.0",
   "devDependencies": {
+    "husky": "^9.0.11",
+    "prettier": "^3.2.5",
     "renovate": "^37.0.0"
   },
   "engines": {

--- a/updatePackageRules.js
+++ b/updatePackageRules.js
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+
+const fs = require("fs");
+const path = require("path");
+
+const scriptPath = path.join(__dirname, "commands", "husky-v9-patch.js");
+const configPath = path.join(__dirname, "default.json");
+
+function encodeFileToBase64(filePath) {
+  return fs.readFileSync(filePath, { encoding: "base64" });
+}
+
+function updateRenovateConfig(encodedCommand) {
+  const config = JSON.parse(fs.readFileSync(configPath, { encoding: "utf8" }));
+  const targetRule = config.packageRules.find(
+    (rule) =>
+      rule.matchPackagePatterns?.includes("^husky$") &&
+      rule.matchUpdateTypes?.includes("major")
+  );
+
+  if (targetRule) {
+    const command = `node -e "eval(Buffer.from('${encodedCommand}', 'base64').toString('utf-8'))"`;
+    targetRule.postUpgradeTasks = targetRule.postUpgradeTasks || {};
+    targetRule.postUpgradeTasks.commands = [command];
+    targetRule.postUpgradeTasks.fileFilters = [
+      "package.json",
+      ".husky/pre-commit",
+    ];
+
+    fs.writeFileSync(configPath, JSON.stringify(config, null, 2), {
+      encoding: "utf8",
+    });
+    console.log("Renovate configuration updated successfully.");
+  } else {
+    console.log("Target package rule not found.");
+  }
+}
+
+const encodedScript = encodeFileToBase64(scriptPath);
+updateRenovateConfig(encodedScript);


### PR DESCRIPTION
Allow the use of a fully-formatted node.js scripts
for postUpgradeTasks by automatically encoding them
and updating default.json in pre-commit.