### PR TITLE
Separate each major version of dependencies

### DIFF
--- a/default.json
+++ b/default.json
@@ -12,7 +12,8 @@
     ":automergePatch",
     ":automergeDigest",
     "npm:unpublishSafe",
-    ":semanticCommitsDisabled"
+    ":semanticCommitsDisabled",
+    ":separateMultipleMajorReleases"
   ],
   "username": "balena-renovate[bot]",
   "gitAuthor": "Self-hosted Renovate Bot <133977723+balena-renovate[bot]@users.noreply.github.com>",


### PR DESCRIPTION
Rather than creating a single PR to hop from 10.x to 12.x, there will be separate PRs created for 11.x and 12.x so we can choose which to merge.

See: https://docs.renovatebot.com/presets-default/#separatemultiplemajorreleases

Change-type: patch