### PR TITLE
Use custom versioning for Minio

### DIFF
--- a/default.json
+++ b/default.json
@@ -91,6 +91,18 @@
         ],
         "fileFilters": ["package.json", ".husky/pre-commit"]
       }
+    },
+    {
+      "description": "Use custom versioning for Minio",
+      "matchDatasources": ["docker"],
+      "versioning": "regex:^RELEASE\\.(?<major>\\d+)-(?<minor>\\d+)-(?<patch>\\d+)T.*Z(-(?<compatibility>.*))?$",
+      "matchPackageNames": [
+        "quay.io/minio/minio",
+        "quay.io/minio/mc",
+        "minio/minio",
+        "minio/mc"
+      ],
+      "automerge": false
     }
   ]
 }


### PR DESCRIPTION
Disable automerge to avoid breaking changes introduced on arbitrary dates.