### PR TITLE
Group GitHub Actions patch and digest updates together

### DIFF
--- a/default.json
+++ b/default.json
@@ -105,6 +105,12 @@
       ],
       "groupName": "minio",
       "automerge": false
+    },
+    {
+      "description": "Group GitHub Actions patch and digest updates",
+      "groupName": "GitHub Actions",
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["patch", "digest"]
     }
   ]
 }

--- a/default.json
+++ b/default.json
@@ -14,7 +14,8 @@
     "npm:unpublishSafe",
     ":semanticCommitsDisabled",
     ":separateMultipleMajorReleases",
-    "group:vitestMonorepo"
+    "group:vitestMonorepo",
+    "group:githubArtifactActions"
   ],
   "onboarding": false,
   "requireConfig": "optional",


### PR DESCRIPTION
This is primarily to reduce the number of active PRs and test runs.

Change-type: patch