### PR TITLE
Use minimum release age for Bitwarden clients

### DIFF
--- a/.github/workflows/renovate-dry-run.yml
+++ b/.github/workflows/renovate-dry-run.yml
@@ -29,4 +29,5 @@ jobs:
     with:
       config_file: ${{ matrix.config_file }}
       dry_run: ${{ inputs.dry_run || github.event_name == 'pull_request' }}
+      repositories: ${{ github.repository }}
       

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -16,6 +16,10 @@ on:
         type: string
         required: true
         description: "The config file to use for Renovate."
+      repositories:
+        type: string
+        required: false
+        description: "Comma-separated repos for Renovate to process. Leave empty to use the config file's repositories."
       runs-on:
         type: string
         required: false
@@ -35,6 +39,9 @@ env:
   # renovate: datasource=npm depName=npm
   NPM_VERSION: 11.12.1
   RENOVATE_DRY_RUN: ""
+  RENOVATE_ONBOARDING: "false"
+  RENOVATE_REQUIRE_CONFIG: "optional"
+  RENOVATE_PRINT_CONFIG: ${{ inputs.dry_run }}
 
 # https://docs.github.com/en/actions/using-jobs/using-concurrency
 # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/control-the-concurrency-of-workflows-and-jobs
@@ -137,6 +144,12 @@ jobs:
       - name: Enable dry-run
         run: echo "RENOVATE_DRY_RUN=full" >> "${GITHUB_ENV}"
         if: inputs.dry_run
+
+      - name: Forward repositories input to Renovate env
+        if: inputs.repositories != ''
+        env:
+          REPOS: ${{ inputs.repositories }}
+        run: echo "RENOVATE_REPOSITORIES=${REPOS}" >> "${GITHUB_ENV}"
 
       # Use local S3 cache on self-hosted runners
       # https://github.com/tespkg/actions-cache

--- a/default.json
+++ b/default.json
@@ -112,6 +112,12 @@
       "automerge": false
     },
     {
+      "description": "Use minimum release age for Bitwarden clients",
+      "matchDepNames": ["bitwarden/clients"],
+      "matchDatasources": ["github-releases"],
+      "minimumReleaseAge": "3 days"
+    },
+    {
       "description": "Group GitHub Actions updates",
       "groupName": "GitHub Actions",
       "matchManagers": ["github-actions"],

--- a/default.json
+++ b/default.json
@@ -17,10 +17,6 @@
     "group:vitestMonorepo",
     "group:githubArtifactActions"
   ],
-  "onboarding": false,
-  "repositories": ["balena-io/renovate-config"],
-  "requireConfig": "optional",
-  "printConfig": true,
   "prHourlyLimit": 0,
   "cloneSubmodules": false,
   "rebaseWhen": "behind-base-branch",


### PR DESCRIPTION
Delay version updates for critical components that may be attack
vectors for leaking credentials.

See: https://balena.fibery.io/Security/Vulnerability_or_Exposure/Supply-chain-compromise-in-Bitwarden-client-npm-package-120