### PR TITLE
Fix client-id assignment in renovate.yml

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -128,7 +128,7 @@ jobs:
         with:
           # https://github.com/apps/balena-renovate
           # https://github.com/organizations/product-os/settings/apps/balena-renovate
-          app-id: ${{ vars.RENOVATE_APP_ID || '335686' }}
+          client-id: ${{ vars.RENOVATE_APP_ID || '335686' }}
           private-key: ${{ steps.decode.outputs.private-key }}
           owner: ${{ github.repository_owner }}
 


### PR DESCRIPTION
app-id has been replaced by client-id

Change-type: patch