### PR TITLE
Enable preset with best practices from the Renovate maintainers.

### DIFF
--- a/default.json
+++ b/default.json
@@ -3,6 +3,7 @@
   "extends": [
     ":preserveSemverRanges",
     "config:recommended",
+    "config:best-practices",
     "docker:enableMajor",
     "helpers:pinGitHubActionDigests",
     "customManagers:dockerfileVersions",
@@ -51,7 +52,6 @@
   },
   "lockFileMaintenance": {
     "commitBody": "Update {{depName}}\n\nChange-type: patch",
-    "enabled": true,
     "automerge": true
   },
   "ignorePaths": [

--- a/default.json
+++ b/default.json
@@ -77,16 +77,11 @@
       "commitBody": "Update {{depName}} from {{{replace 'v' '' currentVersion}}} to {{{replace 'v' '' newVersion}}}\n\nChange-type: patch"
     },
     {
-      "groupName": "{{{replace '^@types/' '' depName}}}",
-      "matchPackageNames": ["@types/{/,}**"],
+      "description": "Group @types/X with its parent package X so they share a single PR (e.g. react + @types/react)",
+      "matchDatasources": ["npm"],
       "matchDepTypes": ["dependencies", "devDependencies"],
-      "matchDatasources": ["npm"]
-    },
-    {
-      "groupName": "{{depName}}",
-      "matchPackageNames": ["!@types/{/,}**"],
-      "matchDepTypes": ["dependencies", "devDependencies"],
-      "matchDatasources": ["npm"]
+      "matchPackageNames": ["@types/**"],
+      "overrideDepName": "{{replace '^@types/' '' depName}}"
     },
     {
       "matchUpdateTypes": ["minor", "patch"],

--- a/default.json
+++ b/default.json
@@ -137,13 +137,27 @@
       "description": "Disable digest pinning for Flowzone to prevent infinite PR loops between Flowzone and its consumers",
       "matchManagers": ["github-actions"],
       "matchPackageNames": ["product-os/flowzone"],
-      "pinDigests": false
+      "matchUpdateTypes": ["pinDigest"],
+      "enabled": false
     },
     {
       "description": "Disable digest pinning for non-semver GitHub Actions refs (branches, feature tags) to restore pre-v43 behavior",
       "matchManagers": ["github-actions"],
       "matchCurrentVersion": "!/^v?\\d+/",
-      "pinDigests": false
+      "matchUpdateTypes": ["pinDigest"],
+      "enabled": false
+    },
+    {
+      "description": "Skip docker digest pinning for balena-controlled registries (not a primary source of supply chain attack)",
+      "matchDatasources": ["docker"],
+      "matchPackageNames": [
+        "balena/**",
+        "ghcr.io/balena-io/**",
+        "ghcr.io/balena-io-modules/**",
+        "ghcr.io/product-os/**"
+      ],
+      "matchUpdateTypes": ["pinDigest"],
+      "enabled": false
     },
     {
       "description": "Group pre-commit hook updates",
@@ -155,6 +169,18 @@
       "description": "Lower priority for devDependencies updates",
       "matchDepTypes": ["devDependencies"],
       "prPriority": -1
+    },
+    {
+      "description": "Schedule devDependencies updates for weekends (noise reduction)",
+      "matchDepTypes": ["devDependencies"],
+      "schedule": ["every weekend"]
+    },
+    {
+      "description": "Skip range pinning @balena/ npm packages (not a primary source of supply chain attack)",
+      "matchDatasources": ["npm"],
+      "matchPackageNames": ["@balena/**"],
+      "matchUpdateTypes": ["pin"],
+      "enabled": false
     },
     {
       "description": "Schedule pre-commit updates for a small window once per month (noise reduction)",

--- a/default.json
+++ b/default.json
@@ -16,7 +16,8 @@
     ":semanticCommitsDisabled",
     ":separateMultipleMajorReleases",
     "group:vitestMonorepo",
-    "group:githubArtifactActions"
+    "group:githubArtifactActions",
+    "group:allDigest"
   ],
   "prHourlyLimit": 0,
   "cloneSubmodules": false,

--- a/default.json
+++ b/default.json
@@ -20,12 +20,22 @@
   "prHourlyLimit": 0,
   "cloneSubmodules": false,
   "rebaseWhen": "behind-base-branch",
-  "git-submodules": {
-    "enabled": true
-  },
-  "pre-commit": {
-    "enabled": true
-  },
+  "enabledManagers": [
+    "cargo",
+    "custom.regex",
+    "docker-compose",
+    "dockerfile",
+    "git-submodules",
+    "github-actions",
+    "gomod",
+    "helm-values",
+    "helmv3",
+    "kubernetes",
+    "kustomize",
+    "npm",
+    "pip_requirements",
+    "pre-commit"
+  ],
   "labels": ["renovate"],
   "commitBody": "Update {{depName}}\n\nChange-type: patch",
   "prConcurrentLimit": 3,


### PR DESCRIPTION
List explicit enabledManagers to improve overall runtime
and disable features we don't use.

Enable preset with best practices from the Renovate maintainers.

Includes:
-  "config:recommended",
-  "docker:pinDigests",
-  "helpers:pinGitHubActionDigests",
-  ":configMigration",
-  ":pinDevDependencies",
-  "abandonments:recommended",
-  "security:minimumReleaseAgeNpm",
-  ":maintainLockFilesWeekly"

Primarily to mitigate risks of supply-chain attacks.

See: https://docs.renovatebot.com/upgrade-best-practices/#use-the-configbest-practices-preset

See: https://balena.fibery.io/Work/Project/Renovate-Enable-best-practices-preset-2373

##  PR Impact

Compared against a `master` dry-run (same Renovate version, same time window):

### Branch counts

| | Master | This branch | Δ |
|---|---|---|---|
| Total post-filter branches | 522 | 563 | **+41** |
| Repos with at least one branch | 34 | 30 | -4 (7 silenced by balena-docker exclusion, 3 newly active from `:pinDevDependencies`) |

### What's actually changing

| Outcome | Count | Notes |
|---|---|---|
| **New "Pin Dependencies" PRs** (one per repo) | 16 repos | Caused by `:pinDevDependencies` from `config:best-practices`. Each is a single PR rewriting `package.json` ranges to exact versions, plus any unfiltered docker digest pins. Large diff per PR but bounded. Fires on next Renovate run, not weekend-deferred. |
| **Branch renames** (close + reopen) | ~305 close + ~305 open | Side effect of removing the broken `groupName: "{{depName}}"` rule. Old `renovate/major-4-redis` → new `renovate/redis-4.x` style. Same upgrades, new branch names. |
| **`@balena/*` npm exclusion** | 0 unwanted pin PRs | Verified working — `@balena/lint` and friends won't be range-pinned. |
| **Balena-controlled docker exclusion** | 127 docker pinDigest updates suppressed | `balena/**`, `ghcr.io/balena-io/**`, `ghcr.io/balena-io-modules/**`, `ghcr.io/product-os/**` correctly excluded. |
| **Non-balena docker images that WILL get digest-pinned** | 161 update entries across 49 distinct images | Bundled into the 16 Pin Dependencies PRs. Top images: `alpine` (8), `docker` (5), `node` (4), `minio/minio` (4), `minio/mc` (4), `grafana/loki` (4). |
| **Weekend-deferred PRs** | Single-digit | `every weekend` schedule applies only to npm `devDependencies` + `digest` updates. |

### Repos getting a new "Pin Dependencies" PR (16)

```
analytics-backend         deploy-to-balena-action
balena-admin              environment-production
balena-api                environments-base
balena-cloud              logs-to-vector
balena-delta              open-balena-api
balena-img                open-balena-db
balena-mdns-publisher     open-balena-vpn
balena-proxy              pinejs
```

### What this PR does NOT do

- Does not change Renovate version
- Does not change automerge policy
- Does not enable any new managers (only formalizes the existing implicit list)
- Does not affect repos already excluded from Renovate
