### PR TITLE
Clarify the behaviour of disabling pinDigest PRs

### DIFF
--- a/default.json
+++ b/default.json
@@ -133,18 +133,16 @@
       "description": "Disable digest pinning for Flowzone to prevent infinite PR loops between Flowzone and its consumers",
       "matchManagers": ["github-actions"],
       "matchPackageNames": ["product-os/flowzone"],
-      "matchUpdateTypes": ["pinDigest"],
-      "enabled": false
+      "pinDigests": false
     },
     {
       "description": "Disable digest pinning for non-semver GitHub Actions refs (branches, feature tags) to restore pre-v43 behavior",
       "matchManagers": ["github-actions"],
       "matchCurrentVersion": "!/^v?\\d+/",
-      "matchUpdateTypes": ["pinDigest"],
-      "enabled": false
+      "pinDigests": false
     },
     {
-      "description": "Skip docker digest pinning for balena-controlled registries (not a primary source of supply chain attack)",
+      "description": "Disable pinDigest PRs for balena-controlled registries (defer digest pinning until they have a new version)",
       "matchDatasources": ["docker"],
       "matchPackageNames": [
         "balena/**",


### PR DESCRIPTION
Disabling PRs of type pinDigest does not prevent future update types from including digests. It only disables the initial PR to add all the digests where missing.

For github-actions pinned to semver, we want digests fully disabled.

For balena-controlled registries, we are okay with including digests on updates.

Change-type: patch