### PR TITLE
Remove group:allDigest preset

### DIFF
--- a/default.json
+++ b/default.json
@@ -16,8 +16,7 @@
     ":semanticCommitsDisabled",
     ":separateMultipleMajorReleases",
     "group:vitestMonorepo",
-    "group:githubArtifactActions",
-    "group:allDigest"
+    "group:githubArtifactActions"
   ],
   "prHourlyLimit": 0,
   "cloneSubmodules": false,


### PR DESCRIPTION
The intent was to reduce the PR churn, which this preset does, but it also has the effect of grouping all git-submodule PRs which is not desirable. Especially as balena-os is going to extend this config soon.

See: https://balena.fibery.io/Work/Project/Renovate-Enable-best-practices-preset-2373