### PR TITLE
default.json: Restore enabled flags for beta managers

### DIFF
--- a/default.json
+++ b/default.json
@@ -37,6 +37,12 @@
     "pip_requirements",
     "pre-commit"
   ],
+  "git-submodules": {
+    "enabled": true
+  },
+  "pre-commit": {
+    "enabled": true
+  },
   "labels": ["renovate"],
   "commitBody": "Update {{depName}}\n\nChange-type: patch",
   "prConcurrentLimit": 3,


### PR DESCRIPTION
git-submodules and pre-commit are beta managers and still require the enabled flag in addition to the enabledManagers array.

Change-type: patch