### PR TITLE
Remove types grouping rule

### DIFF
--- a/default.json
+++ b/default.json
@@ -83,13 +83,6 @@
       "commitBody": "Update {{depName}} from {{{replace 'v' '' currentVersion}}} to {{{replace 'v' '' newVersion}}}\n\nChange-type: patch"
     },
     {
-      "description": "Group @types/X with its parent package X so they share a single PR (e.g. react + @types/react)",
-      "matchDatasources": ["npm"],
-      "matchDepTypes": ["dependencies", "devDependencies"],
-      "matchPackageNames": ["@types/**"],
-      "overrideDepName": "{{replace '^@types/' '' depName}}"
-    },
-    {
       "matchUpdateTypes": ["minor", "patch"],
       "matchCurrentVersion": "!/^v?0/",
       "automerge": true


### PR DESCRIPTION
This rule used overrideDepName to strip the "@types/" prefix from depName but Renovate uses this depName when writing the final version changes, leading to the "@types/" version being used as the target version for the non-types package.

Switch to groupName, which only affects PR/branch grouping and leaves each dependency's identity intact for file edits.

Change-type: patch

---

An example of this problem: https://github.com/balena-io-modules/balena-pricing/pull/53

The PR description mentions updating `chai` from `^6.0.0` to `6.2.2`, but the actual file change is trying to downgrade it to `5.2.3` which doesn't exist. This is the current version for `@types/chai` though. Same goes for `mocha` and `@types/mocha`.

<img width="1465" height="834" alt="pin_diff" src="https://github.com/user-attachments/assets/472574c8-bf5c-4c2f-866d-9a8ca5252b6e" />
