### PR TITLE
packageRules: Add change-type footer for all non-versioned updates

### DIFF
--- a/default.json
+++ b/default.json
@@ -49,15 +49,12 @@
   "automerge": false,
   "automergeStrategy": "merge-commit",
   "pinDigest": {
-    "commitBody": "Update {{depName}}\n\nChange-type: patch",
     "automerge": true
   },
   "digest": {
-    "commitBody": "Update {{depName}}\n\nChange-type: patch",
     "automerge": true
   },
   "lockFileMaintenance": {
-    "commitBody": "Update {{depName}}\n\nChange-type: patch",
     "automerge": true
   },
   "ignorePaths": [
@@ -79,6 +76,20 @@
       "allowedVersions": "<=11.6.0 || >=11.6.3"
     },
     {
+      "description": "Add change-type footer for all non-major/minor/patch updates",
+      "matchUpdateTypes": [
+        "pin",
+        "pinDigest",
+        "digest",
+        "lockFileMaintenance",
+        "rollback",
+        "bump",
+        "replacement"
+      ],
+      "commitBody": "Update {{depName}}\n\nChange-type: patch"
+    },
+    {
+      "description": "Add change-type footer for all major/minor/patch updates - includes current and new version numbers for nested changelogs",
       "matchUpdateTypes": ["major", "minor", "patch"],
       "commitBody": "Update {{depName}} from {{{replace 'v' '' currentVersion}}} to {{{replace 'v' '' newVersion}}}\n\nChange-type: patch"
     },


### PR DESCRIPTION
Where this config is extended (balena-os) the top level commitBody rule is not easily inherited when other package rules are in play.

By ensuring a packageRule exists that explicitly sets the commitBody for each update type, we can ensuring the ordering of config inheritance is respected.

See: https://balena.fibery.io/Work/Improvement/Fix-incorrect-versionist-footers-in-balena-os-PRs-4554