### PR TITLE
workflows/renovate: Enforce npm min-release-age for lock file maintenance

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -38,6 +38,12 @@ env:
   RENOVATE_VERSION: 43.288.0-full
   # renovate: datasource=npm depName=npm
   NPM_VERSION: 11.19.0
+  # Renovate's `minimumReleaseAge` does not apply to `lockFileMaintenance`, because
+  # Renovate delegates the resolution to the package manager and never looks up a
+  # release timestamp. Have npm apply the same age gate itself, so lock file refreshes
+  # cannot pull in a package published minutes ago.
+  # https://docs.npmjs.com/cli/v11/using-npm/config#min-release-age
+  NPM_CONFIG_MIN_RELEASE_AGE: "3"
   RENOVATE_DRY_RUN: ""
   RENOVATE_ONBOARDING: "false"
   RENOVATE_REQUIRE_CONFIG: "optional"
@@ -197,7 +203,7 @@ jobs:
           docker-cmd-file: ${{ runner.temp }}/entrypoint.sh
           docker-user: root
           # https://github.com/renovatebot/github-action?tab=readme-ov-file#env-regex
-          env-regex: "^(?:RENOVATE_\\w+|LOG_LEVEL|AWS_\\w+)$"
+          env-regex: "^(?:RENOVATE_\\w+|LOG_LEVEL|AWS_\\w+|NPM_CONFIG_MIN_RELEASE_AGE)$"
         env:
           AWS_REGION: ${{ env.AWS_REGION }}
           AWS_DEFAULT_REGION: ${{ env.AWS_REGION }}


### PR DESCRIPTION
Renovate's `minimumReleaseAge` doesn't apply to `lockFileMaintenance`. It's excluded in core, and `security:minimumReleaseAgeNpm` nulls it out too, both for the same reason: Renovate hands the resolution to the package manager and never looks up a release timestamp.

So our weekly lock file refresh has been pulling in whatever npm resolves, ignoring the 3 day window we apply everywhere else. product-os/flowzonify#39 picked up `electron-to-chromium` 1.5.408 about 48 minutes after it was published, then automerged 3 minutes later.

npm 11 has its own `min-release-age`, so let npm enforce the gate at the layer that actually does the resolving. This covers every repo without touching any of them.

Setting the env var alone isn't enough, since `env-regex` on the renovate action only forwards the vars it matches. That's the second line.

This also closes the other half of renovatebot/renovate#38115, transitive deps pulled in by a normal update. Renovate ages the direct dependency correctly but npm still picks the newest transitive one. The env var applies to every npm call Renovate makes, not just lock file maintenance.

Upstream is building this natively in renovatebot/renovate#41652, so we can drop the workaround when that lands.

Worth knowing:
- npm re-resolves the entire tree, unlike uv, so it fails more readily when the lockfile already references something newer than the cutoff. See the implementation guidance in #41652 for the cases that trigger it. If it gets noisy we can add `min-release-age-exclude` for `@balena/**`, which we already treat as outside the supply chain threat model.
- npm/cli#9005 means `min-release-age` can error on deps using `~` ranges.

Both of those fail loudly rather than merging quietly, which is the direction I want.

See: https://docs.npmjs.com/cli/v11/using-npm/config#min-release-age
