### PR TITLE
fix: set binarySource=install so tool constraints are honored

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -214,6 +214,10 @@ jobs:
           GIT_CONFIG_KEY_0: "url.https://x-access-token:${{ steps.app_token.outputs.token }}@github.com/.insteadOf"
           GIT_CONFIG_VALUE_0: "https://github.com/"
           RENOVATE_DRY_RUN: ${{ env.RENOVATE_DRY_RUN }}
+          # Install tools at runtime so `constraints` (e.g. helm version) are honored
+          # https://docs.renovatebot.com/self-hosted-configuration/#self-hosted-configuration-options
+          # https://docs.renovatebot.com/self-hosted-configuration/#binarysource
+          RENOVATE_BINARY_SOURCE: install
           RENOVATE_HOST_RULES: |
             [
               {


### PR DESCRIPTION
Renovate ran with binarySource=global, so it used the helm binary baked into the renovate image (v4.2.3) and ignored `constraints.helm`. The debug log confirmed: "Ignoring tool constraints because of binarySource=global".

Switch to binarySource=install so containerbase installs tools at runtime and applies each repo's constraint (e.g. helm 4.2.4). Repos without a constraint keep the image default version.

Change-type: patch