### PR TITLE
workflows/renovate: Drop the npm entrypoint in favour of tool constraints

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -36,8 +36,6 @@ env:
   LOG_LEVEL: debug
   # renovate: datasource=docker depName=renovate packageName=ghcr.io/renovatebot/renovate
   RENOVATE_VERSION: 44.38.0-full
-  # renovate: datasource=npm depName=npm
-  NPM_VERSION: 11.19.0
   # Renovate's `minimumReleaseAge` does not apply to `lockFileMaintenance`, because
   # Renovate delegates the resolution to the package manager and never looks up a
   # release timestamp. Have npm apply the same age gate itself, so lock file refreshes
@@ -160,37 +158,6 @@ jobs:
           mkdir -p "${RENOVATE_CACHE_DIR}"
           sudo chown -R 12021:0 "$(dirname "${RENOVATE_CACHE_DIR}")"
 
-      - name: Write out entrypoint script
-        run: |
-          cat <<EOF > ${{ runner.temp }}/entrypoint.sh
-          #!/bin/bash
-          set -euo pipefail
-
-          echo "=== npm version before install ==="
-          npm --version
-
-          echo "=== Installing npm@${NPM_VERSION} ==="
-          npm install -g "npm@${NPM_VERSION}" --loglevel verbose
-
-          echo "=== npm version after install ==="
-          INSTALLED_VERSION=\$(npm --version)
-          echo "Installed: \${INSTALLED_VERSION}"
-
-          if [[ "\${INSTALLED_VERSION}" != "${NPM_VERSION}" ]]; then
-            echo "ERROR: npm version mismatch! Expected ${NPM_VERSION}, got \${INSTALLED_VERSION}"
-            exit 1
-          fi
-
-          echo "=== npm location ==="
-          which npm
-
-          # Run renovate as the ubuntu user (container default)
-          exec runuser -u ubuntu -- renovate
-          
-          EOF
-
-          chmod +x ${{ runner.temp }}/entrypoint.sh
-
       # https://github.com/renovatebot/github-action
       - uses: renovatebot/github-action@e09d604f8f803bb527bd8321ed5be06c460b8682 # v46.2.2
         with:
@@ -199,9 +166,6 @@ jobs:
           configurationFile: ${{ inputs.config_file }}
           token: ${{ steps.app_token.outputs.token }}
           renovate-version: ${{ env.RENOVATE_VERSION }}
-          # Custom entrypoint to install pinned npm version before running renovate
-          docker-cmd-file: ${{ runner.temp }}/entrypoint.sh
-          docker-user: root
           # https://github.com/renovatebot/github-action?tab=readme-ov-file#env-regex
           env-regex: "^(?:RENOVATE_\\w+|LOG_LEVEL|AWS_\\w+|NPM_CONFIG_MIN_RELEASE_AGE)$"
         env:
@@ -214,7 +178,9 @@ jobs:
           GIT_CONFIG_KEY_0: "url.https://x-access-token:${{ steps.app_token.outputs.token }}@github.com/.insteadOf"
           GIT_CONFIG_VALUE_0: "https://github.com/"
           RENOVATE_DRY_RUN: ${{ env.RENOVATE_DRY_RUN }}
-          # Install tools at runtime so `constraints` (e.g. helm version) are honored
+          # Install tools at runtime so `constraints` are honored. This is also how
+          # the npm version is pinned: `constraints.npm` in the shared config, rather
+          # than installing npm globally from a custom container entrypoint.
           # https://docs.renovatebot.com/self-hosted-configuration/#self-hosted-configuration-options
           # https://docs.renovatebot.com/self-hosted-configuration/#binarysource
           RENOVATE_BINARY_SOURCE: install

--- a/default.json
+++ b/default.json
@@ -85,7 +85,7 @@
   },
   "packageRules": [
     {
-      "description": "Avoid using npm 11.6.1 & 11.6.2 b/c of bug: https://github.com/npm/cli/issues/8628",
+      "description": "Avoid using npm 11.6.1 & 11.6.2 b/c of bug: https://github.com/npm/cli/issues/8628. The matching constraints.npm range also selects the npm version installed at runtime, since binarySource=install.",
       "matchPackageNames": ["npm"],
       "allowedVersions": "<=11.6.0 || >=11.6.3"
     },


### PR DESCRIPTION
The entrypoint installed npm globally to avoid npm 11.6.1 and 11.6.2:
https://github.com/npm/cli/issues/8628. It was the only lever available under
binarySource=global, because Renovate discards constraints entirely in that
mode.

Since https://github.com/balena-io/renovate-config/pull/1930 switched to binarySource=install, containerbase installs npm from
`constraints.npm` for the calls that need it. Observed in a product-os run: the
entrypoint installed npm 11.19.0, then Renovate ran `install-tool npm 12.0.2` to
generate a lock file, so the pinned global npm was already being bypassed.

postUpgradeTasks are the exception. They pass no toolConstraints, so they use
whatever npm is on PATH, moving from 11.19.0 to the image default. Both current
tasks are unaffected in practice: the husky migration calls node, and flowzonify
runs `npm exec` against a git tarball.